### PR TITLE
Fix build process for Next 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ Proyecto de ejemplo con Next.js y Tailwind CSS para mostrar una landing page pro
 ## Scripts
 
 - `npm run dev` - Levanta el entorno de desarrollo.
-- `npm run build` - Compila la aplicación y exporta los archivos estáticos en `public/`.
+- `npm run build` - Compila la aplicación y exporta los archivos estáticos en `out/`.
 - `npm start` - Inicia la versión de producción.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export'
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export -o public",
+    "build": "next build",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `next.config.js` enabling `output: 'export'`
- remove obsolete `next export` command
- update docs

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8e204fa0833386b0c0219bc0bf9e